### PR TITLE
Eslint-ify

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+    "extends": "airbnb",
+    "installedESLint": true
+}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ The service worker caches files listed in the manifest when the "save" button is
 
 Warning: the code is really rough, as I don't know what I'm doing.
 
+## Usage
+
+Use `python -m SimpleHTTPServer` to host the repo at `http://localhost:8000/`
+
+## Contributing
+
+Currently, the repository is a mix of ES5 and ES6/ES2015. We are using [eslint](http://eslint.org/) and the
+[AirBnB JavaScript code styles](https://github.com/airbnb/javascript) to keep things tidy.
+`kroner.js` is the one ES6/ES2015 file we have atm, so to lint it do the following:
+
+```
+$ npm i -g eslint eslint-config-airbnb # once to install things
+$ eslint kroner.js # prior to committing changes
+```
+
 ## Acknowledgments
 
 [Jake Archibald](https://jakearchibald.github.io/ebook-demo/publisher-site/readme/) wrote the original service worker (`kroner.js`) and `page.js` files. The manifest format was hashed out with Hadrien Gardeur. All of this is really the work of the entire DPUB/EPUB community. 

--- a/kroner.js
+++ b/kroner.js
@@ -46,7 +46,7 @@ function packagePublication(request) {
     .has(publicationName)
     .then(isCached => (isCached ? caches.open(publicationName).then(c => c.match.bind(c)) : fetch))
     .then(fetchingMethod =>
-      fetchingMethod(`${publicationBaseURL}${publicationName}/manifest.json`)
+      fetchingMethod(`${publicationName}/manifest.json`)
         .then(r => r.json())
         .then((data) => {
           const zip = new JSZip();
@@ -63,7 +63,7 @@ function packagePublication(request) {
           return Promise.all(data.resources
             .map(el => el.href)
             .map(path =>
-              fetchingMethod(`${publicationBaseURL}${publicationName}/${path}`)
+              fetchingMethod(`${publicationName}/${path}`)
                 .then((response) => {
                   if (!path || path.endsWith('/')) path += 'index.html';
                   types[path] = response.headers.get('Content-Type');
@@ -77,7 +77,7 @@ function packagePublication(request) {
           .then(data.spine
             .map(el => el.href)
             .map(path =>
-              fetchingMethod(`${publicationBaseURL}${publicationName}/${path}`)
+              fetchingMethod(`${publicationName}/${path}`)
                 .then(response => response.arrayBuffer())
                 .then((arrayBuffer) => {
                   zip.file(path, arrayBuffer, { createFolders: true });
@@ -108,6 +108,5 @@ function packagePublication(request) {
         })
   );
 }
-
 
 

--- a/kroner.js
+++ b/kroner.js
@@ -1,7 +1,9 @@
-// v2
+/* global importScripts self caches clients JSZip */
+/* eslint comma-dangle:0 */
+/* eslint-env browser */
 importScripts('jszip.js');
 
-self.addEventListener('install', event => {
+self.addEventListener('install', (event) => {
   self.skipWaiting();
   event.waitUntil(
     caches.open('pub-static-v1').then(c => c.addAll([
@@ -13,118 +15,98 @@ self.addEventListener('install', event => {
   );
 });
 
-self.addEventListener('activate', event => {
+self.addEventListener('activate', () => {
   clients.claim();
 });
 
-self.addEventListener('fetch', event => {
+self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
   const sameOrigin = url.origin === location.origin;
-  
+
   if (sameOrigin && url.pathname.endsWith('/download-publication')) {
     event.respondWith(packagePublication(event.request));
     return;
   }
 
   event.respondWith(
-    caches.match(event.request).then(response => {
-      return response || fetch(event.request);
-    })
+    caches
+      .match(event.request)
+      .then(response => response || fetch(event.request))
   );
 });
 
 function packagePublication(request) {
   // more hacky url stuff that can probably be done better
-const urlRE = /\/([^\/]*)\/download-publication/.exec(request.url);
- // const publicationName = urlRE[1];
-//  const publicationBaseURL = urlRE[0];
+  const urlRE = /\/([^\/]*)\/download-publication/.exec(request.url);
 
-  
-    var publicationBaseURL = location.origin + '/epub-zero/acme/'
+  const publicationBaseURL = `${location.origin}/epub-zero/acme/`;
+  const publicationName = urlRE[1];
 
-  var publicationName = urlRE[1];
-//  var fileName = urlRE[1];
-  console.log(publicationName);
-  
- // console.log(request.url);
- console.log(publicationBaseURL + publicationName + '/manifest.json');
-   
-  return caches.has(publicationName).then(isCached => {
-    return isCached ? caches.open(publicationName).then(c => c.match.bind(c)) : fetch;
-  }).then(fetchingMethod => {
-    return fetchingMethod(publicationBaseURL + publicationName + '/manifest.json').then(r => r.json()).then(data => {
-      const zip = new JSZip();
-      const types = {};
-      var manifestContent = JSON.stringify(data);
-      
- //  zip.file('manifest.json', manifestContent);
+  return caches
+    .has(publicationName)
+    .then(isCached => (isCached ? caches.open(publicationName).then(c => c.match.bind(c)) : fetch))
+    .then(fetchingMethod =>
+      fetchingMethod(`${publicationBaseURL}${publicationName}/manifest.json`)
+        .then(r => r.json())
+        .then((data) => {
+          const zip = new JSZip();
+          const types = {};
+          const manifestContent = JSON.stringify(data);
 
-      // I should reuse the asset I just downloaded but I'm lazy
-      data.spine.map(function(el) { return el.href}).push(publicationName + '/manifest.json');
+          //  zip.file('manifest.json', manifestContent);
 
-      return Promise.all(
-        data.resources.map(function(el) { return el.href}).map(path => {
-        console.log(path);
-       
-          return fetchingMethod(publicationBaseURL + publicationName + '/' + path).then(response => {
-            if (!path || path.endsWith('/')) path += 'index.html';
-            types[path] = response.headers.get('Content-Type');
-            
-            return response.arrayBuffer();
-            
-    
-            
-          }).then(arrayBuffer => {
-            
-            zip.file(path, arrayBuffer, {createFolders: true});
+          // I should reuse the asset I just downloaded but I'm lazy
+          data.spine
+            .map(el => el.href)
+            .push(`${publicationName}/manifest.json`);
+
+          return Promise.all(data.resources
+            .map(el => el.href)
+            .map(path =>
+              fetchingMethod(`${publicationBaseURL}${publicationName}/${path}`)
+                .then((response) => {
+                  if (!path || path.endsWith('/')) path += 'index.html';
+                  types[path] = response.headers.get('Content-Type');
+                  return response.arrayBuffer();
+                })
+                .then((arrayBuffer) => {
+                  zip.file(path, arrayBuffer, { createFolders: true });
+                })
+            )
+          )
+          .then(data.spine
+            .map(el => el.href)
+            .map(path =>
+              fetchingMethod(`${publicationBaseURL}${publicationName}/${path}`)
+                .then(response => response.arrayBuffer())
+                .then((arrayBuffer) => {
+                  zip.file(path, arrayBuffer, { createFolders: true });
+                })
+            )
+          )
+          .then(() => {
+            zip.file('manifest.json', manifestContent);
+            //  console.log(manifestContent);
+
+            const zipArray = new Uint8Array(zip.generate({
+              type: 'uint8array',
+              compression: 'STORE'
+            }));
+            const resultArray = new Uint8Array(zipArray.length + 1);
+
+            // don't 'encode' the archive
+            for (let i = 0; i < zipArray.length; i++) {
+              resultArray[i + 1] = zipArray[i + 1];
+            }
+
+            return new Response(resultArray.buffer, {
+              headers: {
+                'Content-Disposition': `attachment; filename="${publicationName}.zip"`
+              }
+            });
           });
         })
-      ).then(
-        data.spine.map(function(el) { return el.href}).map(path => {
-        console.log(path);
-          return fetchingMethod(publicationBaseURL + publicationName + '/' + path).then(response => {
-          //  if (!path || path.endsWith('/')) path += 'index.html';
-         //   types[path] = response.headers.get('Content-Type');
-         
-     //     var myRe = /([^/]*)/g;
-      //  myPath = myRe.exec(path);
-    //    console.log(myPath)
-    //    zip.folder(myPath[0]);
-         
-        console.log(response.arrayBuffer);
-            return response.arrayBuffer();
-          }).then(arrayBuffer => {
-          
-         
-                        zip.file(path, arrayBuffer, {createFolders: true});
-            
-          //  console.log(path);
-           // console.log(arrayBuffer);
-          });
-        })
-      ).then(_ => {
-   zip.file('manifest.json', manifestContent);
- //  console.log(manifestContent);
-
-        const zipArray = new Uint8Array(zip.generate({
-          type: 'uint8array',
-          compression: 'STORE'
-        }));
-        const resultArray = new Uint8Array(zipArray.length + 1);
-
-        // don't 'encode' the archive
-        for (var i = 0; i < zipArray.length; i++) {
-          resultArray[i+1] = zipArray[i+1];
-        }
-
-        return new Response(resultArray.buffer, {
-          headers: {
-            'Content-Disposition': 'attachment; filename="' + publicationName + '.zip"'
-          }
-        });
-      });
-    });
-  });
+  );
 }
 
 

--- a/page.js
+++ b/page.js
@@ -3,8 +3,6 @@
   var thisScriptURL = document.currentScript.src;
   // some nasty url hacking that should probably be done some other way
   var urlRE = /^.*acme\/([^\/]+)\//.exec(location.href);
-  var publicationBaseURL = location.origin + '/epub-zero/acme/';
-  // var publicationBaseURL = '/' + getPathByName() + '/';
 
   //what folder is the manifest in
   function getPathByName() {
@@ -36,9 +34,9 @@
     caches.has(publicationName).then(function(isCached) {
       ui.innerHTML =
         '<span><label class="status"><input type="checkbox" class="work-offline">Save</label></span>'
-        + '<form method="get" action="' + publicationBaseURL + publicationName
+        + '<form method="get" action="' + publicationName
         + '/download-publication"><button type="submit">Download</button></form>';
-        //      '<span class="download"><a href="' + publicationBaseURL + publicationName + '/download-publication">Download</a></span>';
+        //      '<span class="download"><a href="' + publicationName + '/download-publication">Download</a></span>';
 
       var status = ui.querySelector('.status');
       var checkbox = ui.querySelector('.work-offline');
@@ -50,7 +48,7 @@
           status.textContent = "Removed";
         } else {
          status.textContent = "Offlinifying";
-          fetch(publicationBaseURL + publicationName + '/manifest.json', { mode: 'no-cors' })
+          fetch(publicationName + '/manifest.json', { mode: 'no-cors' })
             .then(function(response) {
               return response.json();
             })
@@ -60,7 +58,7 @@
             })
             .then(function(data) {
               data.push('manifest.json');
-              publicationURL = publicationBaseURL + publicationName;
+              publicationURL = publicationName;
 
               return caches.open(publicationName).then(function(cache) {
                 return cache.addAll(data.map(function(url) {


### PR DESCRIPTION
Explains using [eslint](http://eslint.org/) to make the code cleaner and more awesomer. :wink:

Only setup to work ES6 files atm (i.e. kroner.js).

Also, this fixes the `publicationBaseURL` issue--links to download going to old location. However, there's not any "cache-busting" yet, so you won't be able to tell without deleting the old local/cache/offline-ified version "by hand." That issue only effects folks who've used it before...but...yeah...that's most of us. ;)

I'll try and tackle that soon.